### PR TITLE
Adding a new check_use_of_init function for use of func init()

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -237,7 +237,7 @@ def go_vet(package):
         print("GO VET: PASS")
 
 
-def grep_init(package):
+def check_use_of_init(package):
     """
 
     Runs grep recursively through the source folder looking for instances of
@@ -260,10 +260,23 @@ def grep_init(package):
 
     if out != '':
         lines = out.split('\n')
+        package_pattern = re.compile(package + r'(\/[a-z\/]+)?.go')
+        file_pattern = re.compile(r'\/[a-z]+.go')
 
         for line in lines:
 
             if "_test.go" in line:
+                continue
+
+            package = re.search(package_pattern, line)
+
+            if package is None:
+                continue
+
+            package = package.group(0)
+            package = re.sub(file_pattern, '', package)
+
+            if package in config.check_use_of_init.ignored_packages:
                 continue
 
             output += (line + '\n')
@@ -308,8 +321,8 @@ for package in config.all.packages:
         go_vet(package)
         print("")
 
-    if "grep_init" not in config.all.ignored_commands:
-        grep_init(package)
+    if "check_use_of_init" not in config.all.ignored_commands:
+        check_use_of_init(package)
         print("")
 
 

--- a/ci.py
+++ b/ci.py
@@ -237,6 +237,47 @@ def go_vet(package):
         print("GO VET: PASS")
 
 
+def grep_init(package):
+    """
+
+    Runs grep recursively through the source folder looking for instances of
+    the init() go function being used.
+
+    """
+    global has_error
+
+    err = False
+    output = ""
+
+    p = subprocess.Popen(
+        ["grep -n -R \"func init()\" src/" + package],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=True)
+
+    out, err_output = p.communicate()
+    output = ""
+
+    if out != '':
+        lines = out.split('\n')
+
+        for line in lines:
+
+            if "_test.go" in line:
+                continue
+
+            output += (line + '\n')
+            err = True
+
+    if err and not has_error:
+        has_error = err
+
+    if err:
+        print("USE OF INIT: FAIL")
+        print(output)
+    else:
+        print("USE OF INIT: PASS")
+
 # Pulled from config.py in the same dir
 if config.all.project_type != "gb":
     print(config.all.project_type)
@@ -265,6 +306,10 @@ for package in config.all.packages:
 
     if "go_vet" not in config.all.ignored_commands:
         go_vet(package)
+        print("")
+
+    if "grep_init" not in config.all.ignored_commands:
+        grep_init(package)
         print("")
 
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,3 +14,6 @@ go_vet:
 
 golint:
   ignored_packages: []
+
+check_use_of_init:
+  ignored_packages: []


### PR DESCRIPTION
Recursively greps the source folder for uses of func init() and errors out if it is not in the ignored packages list for the command.
