### PR TITLE
Making URL readable again

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -244,8 +244,8 @@ def go_timeouts():
         print(output)
 
         hint = "For more info on why this is bad, please read "
-        + "https://blog.cloudflare.com"
-        + "/the-complete-guide-to-golang-net-http-timeouts/"
+        + "https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/" # noqa
+
         print(hint)
         print()
     else:


### PR DESCRIPTION
Ignoring PEP8 on the line length with a URL hint.

http://stackoverflow.com/questions/10739843/how-should-i-format-a-long-url-in-a-python-comment-and-still-be-pep8-compliant